### PR TITLE
Make ERW call-by-value

### DIFF
--- a/Crypto/Alchemy/Interpreter/ErrorRateWriter.hs
+++ b/Crypto/Alchemy/Interpreter/ErrorRateWriter.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Crypto.Alchemy.Interpreter.ErrorRateWriter
+module Crypto.Alchemy.Interpreter.ErrorRateWriter2
 ( ErrorRateWriter, writeErrorRates, Monadify, ErrorRateLog )
 where
 
@@ -29,6 +29,8 @@ import           Crypto.Alchemy.Language.Pair
 import           Crypto.Alchemy.Language.SHE
 import qualified Crypto.Alchemy.Language.String       as LS
 
+import Crypto.Alchemy.Interpreter.Eval
+
 -- | A transformer that additionally logs the sizes of the noise terms
 -- of any ciphertexts created during interpretation.
 newtype ErrorRateWriter
@@ -39,16 +41,15 @@ newtype ErrorRateWriter
   w                             -- | (writer) monad for logging error rates
   e                             -- | environment
   a                             -- | represented type
-  = ERW { unERW :: k (expr (Monadify w e) (Monadify w a)) }
+    = ERW { unERW :: k (expr (Monadify w e) (w (Monadify w a))) }
 
--- EAC: can't make this injective because there's ambiguity involving `w`:
--- Consider `m Bool -> m Bool`: this could be the result of
--- `Monadify (m Bool ->) (m Bool)` or `Monadify m (Bool -> Bool)`
+{--- EAC: can't make this injective because there's ambiguity involving `w`:-}
+{--- Consider `m Bool -> m Bool`: this could be the result of-}
+{--- `Monadify (m Bool ->) (m Bool)` or `Monadify m (Bool -> Bool)`-}
 type family Monadify w a where
-  Monadify w () = ()
-  Monadify w (a,b) = (Monadify w a, Monadify w b)
-  Monadify w (a -> b) = Monadify w a -> Monadify w b
-  Monadify w a = w a
+  Monadify w (a,b) = (Monadify w a, w (Monadify w b))
+  Monadify w (a -> b) = Monadify w a -> w (Monadify w b)
+  Monadify w a = a
 
 type ErrorRateLog = [(String,Double)]
 
@@ -56,7 +57,7 @@ type ErrorRateLog = [(String,Double)]
 -- rates, where the needed keys are obtained from the monad.
 writeErrorRates :: forall z e expr k w a .
   (MonadWriter ErrorRateLog w, MonadReader Keys k)
-  => ErrorRateWriter expr z k w e a -> k (expr (Monadify w e) (Monadify w a))
+  => ErrorRateWriter expr z k w e a -> k (expr (Monadify w e) (w (Monadify w a)))
 writeErrorRates = unERW
 
 -- | Perform the action, then perform the action given by the result,
@@ -66,15 +67,17 @@ after_ = lam $ lam $ bind_ $: v0 $:
          lam (bind_ $: (v2 $: v0) $:
                lam (return_ $: v1))
 
-tellError :: forall mon expr m zp t m' zq z e .
-  (MonadWriter ErrorRateLog mon, Show (ArgType zq),
+tellError :: forall w expr m zp t m' zq z e .
+  (MonadWriter ErrorRateLog w, Show (ArgType zq),
    List expr, MonadWriter_ expr, ErrorRate expr, LS.String expr, Pair expr,
    ErrorRateCtx expr (CT m zp (Cyc t m' zq)) z) =>
-  String -> SK (Cyc t m' z) -> expr e (CT m zp (Cyc t m' zq) -> mon ())
+   String -> SK (Cyc t m' z) -> expr e (CT m zp (Cyc t m' zq) -> w ())
 tellError str sk = lam (tell_ $: (cons_ $: (pair_ $: (LS.string_ $ str ++ showType (Proxy::Proxy zq)) $: (errorRate_ sk $: v0)) $: nil_))
 --
+
+
 type WriteErrorCtx expr z k w ct t m m' zp zq =
-  (MonadWriter ErrorRateLog w, MonadReader Keys k, Typeable (SK (Cyc t m' z)),
+  (MonadWriter ErrorRateLog w, MonadReader Keys k, Typeable (SK (Cyc t m' z)), 
    List expr, LS.String expr, Pair expr, MonadWriter_ expr, ErrorRate expr,
    ct ~ (CT m zp (Cyc t m' zq)), ErrorRateCtx expr ct z, Show (ArgType zq))
 
@@ -85,29 +88,31 @@ liftWriteError :: forall expr z k w ct t m m' zp zq a e .
   => Proxy z
   -> String                     -- | annotation
   -> expr e (a -> ct)           -- | the function to lift
-  -> k (expr e (w a -> w ct))
-liftWriteError _ str f_ =
-  let mf_ = liftA_ $: s f_      -- shift because we use between lam,v0
-  in do
+  -> k (expr e (w (a -> w ct)))
+liftWriteError _ str f_ = do
     key :: Maybe (SK (Cyc t m' z)) <- lookupKey
-    case key of
-      Just sk -> return $ lam $ after_ $: tellError str sk $: (mf_ $: v0)
-      Nothing -> return $ liftA_ $: f_
+    return $ return_ $: case key of
+      Just sk -> lam $ after_ $: tellError str sk $: ((return_ .: (s f_)) $: v0)
+      Nothing -> return_ .: f_
+
+-- TODO: this is a hack; liftWriteError2 should be reimplemented without this
+kleislify2 :: (Monad_ expr, Monad m) => expr e ((m a -> m b -> m c) -> a -> m (b -> m c)) 
+kleislify2 = lam $ return_ .: lam (v0 .: return_) .: v0 .: return_
 
 liftWriteError2 :: forall expr z k w ct t m m' zp zq a b e .
   (WriteErrorCtx expr z k w ct t m m' zp zq)
   => Proxy z
   -> String                     -- | annotation
   -> expr e (a -> b -> ct)      -- | the function to lift
-  -> k (expr e (w a -> w b -> w ct))
+  -> k (expr e (w (a -> w (b -> w ct))))
 
 liftWriteError2 _ str f_ =
   let mf_ = liftA2_ $: s (s f_) -- shift because we use between lam/lam,v0/v1
   in do
     key :: Maybe (SK (Cyc t m' z)) <- lookupKey
-    case key of
-      Just sk -> return $ lam $ lam $ after_ $: tellError str sk $: (mf_ $: v1 $: v0)
-      Nothing -> return $ liftA2_ $: f_
+    return $ return_ .: kleislify2 $: case key of
+      Just sk -> lam $ lam $ after_ $: tellError str sk $: (mf_ $: v1 $: v0)
+      Nothing -> liftA2_ $: f_
 
 instance (WriteErrorCtx expr z k w ct t m m' zp zq, Add expr ct) =>
   Add (ErrorRateWriter expr z k w) (CT m zp (Cyc t m' zq)) where
@@ -118,7 +123,7 @@ instance (WriteErrorCtx expr z k w ct t m m' zp zq, Add expr ct) =>
 
 instance (WriteErrorCtx expr z k w ct t m m' zp zq, Mul expr ct,
           -- needed because PreMul could take some crazy form
-          Monadify w (PreMul expr ct) ~ w (PreMul expr ct))
+          Monadify w (PreMul expr ct) ~ PreMul expr ct)
          => Mul (ErrorRateWriter expr z k w) (CT m zp (Cyc t m' zq)) where
 
   type PreMul (ErrorRateWriter expr z k w) (CT m zp (Cyc t m' zq)) =
@@ -137,23 +142,22 @@ instance (WriteErrorCtx expr z k w ct t m m' zp zq, MulLit expr ct) =>
   mulLit_ = ERW . liftWriteError (Proxy::Proxy z) "mulLit_" . mulLit_
 
 instance (WriteErrorCtx expr z k w ct t m m' zp zq,
-          Monadify w (PreDiv2 expr ct) ~ w (PreDiv2 expr ct), ct ~ CT m zp (Cyc t m' zq),
-          Div2 expr ct, Lambda expr, Applicative_ expr, Applicative w, Applicative k)
+          Monadify w (PreDiv2 expr ct) ~ PreDiv2 expr ct, ct ~ CT m zp (Cyc t m' zq),
+          Div2 expr ct, Applicative k)
   => Div2 (ErrorRateWriter expr z k w) (CT m zp (Cyc t m' zq)) where
   type PreDiv2 (ErrorRateWriter expr z k w) (CT m zp (Cyc t m' zq)) =
     PreDiv2 expr (CT m zp (Cyc t m' zq))
 
   div2_ = ERW $ liftWriteError (Proxy::Proxy z) "div2_" div2_
 
------ TRIVIAL WRAPPER INSTANCES -----
+{------ TRIVIAL WRAPPER INSTANCES ------}
 
-instance (Lambda expr, Applicative k)
+instance (Monad_ expr, Monad w, Applicative k)
   => Lambda (ErrorRateWriter expr z k w) where
-
-  lam f  = ERW $ lam <$> unERW f
-  f $: a = ERW $ ($:) <$> unERW f <*> unERW a
+  lam f  = ERW $ fmap ((return_ $:) . (.: return_) . lam) (unERW f)
+  f $: x = ERW $ ((>>=:) <$> (unERW f)) <*> ((bind_ $:) <$> (unERW x))
   v0     = ERW $ pure v0
-  s a    = ERW $ s <$> unERW a
+  s a    = ERW $ s <$> (unERW a)
 
 instance (SHE expr, Applicative_ expr, Applicative k, Applicative w) =>
   SHE (ErrorRateWriter expr z k w) where
@@ -184,9 +188,8 @@ instance (SHE expr, Applicative_ expr, Applicative k, Applicative w) =>
   keySwitchQuad_ = ERW . liftWriteError (Proxy::Proxy z) "keySwitchQuad_" . keySwitchQuad_
   tunnel_        = ERW . liftWriteError (Proxy::Proxy z) "tunnel_" . tunnel_
 
-instance (ErrorRate expr, Applicative_ expr, Applicative k, Applicative w) =>
+instance (ErrorRate expr, Applicative k, MonadWriter ErrorRateLog w, MonadWriter_ expr) =>
   ErrorRate (ErrorRateWriter expr z k w) where
 
   type ErrorRateCtx (ErrorRateWriter expr z' k w) ct z = ErrorRateCtx expr ct z
-
-  errorRate_  sk = ERW $ pure $ liftA_ $: errorRate_ sk
+  errorRate_  sk = ERW . pure $ return_ $: (return_ .: errorRate_ sk)

--- a/alchemy.cabal
+++ b/alchemy.cabal
@@ -75,6 +75,26 @@ executable alchemy-arithmetic
     time,
     type-natural
 
+executable alchemy-ERW
+  hs-source-dirs: examples
+  default-language: Haskell2010
+  main-is: ERW.hs
+  ghc-options: -main-is ERW
+
+  ghc-options: -rtsopts
+
+  build-depends:
+    alchemy,
+    base >= 4.9 && < 4.10,
+    deepseq,
+    lol,
+    lol-cpp,
+    MonadRandom,
+    mtl,
+    numeric-prelude,
+    time,
+    type-natural
+
 executable alchemy-homomrlwr
   hs-source-dirs: examples
   default-language: Haskell2010

--- a/examples/ERW.hs
+++ b/examples/ERW.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+module ERW where
+
+
+import Control.Monad.Writer
+import Control.Monad.Random
+import Data.List
+import Data.Type.Natural (Nat (Z))
+
+import Crypto.Alchemy.MonadAccumulator
+import Crypto.Alchemy.Interpreter.ErrorRateWriter2
+import Crypto.Alchemy.Interpreter.Eval
+import Crypto.Alchemy.Interpreter.KeysHints
+import Crypto.Alchemy.Interpreter.PT2CT
+import Crypto.Alchemy.Interpreter.PT2CT.Noise
+import Crypto.Alchemy.Language.Arithmetic
+import Crypto.Alchemy.Language.Lambda
+import Crypto.Lol hiding (Pos (..))
+import Crypto.Lol.Cyclotomic.Tensor.CPP
+
+import Common
+
+
+type M = F512
+type F = F4
+type M'Map = '[ '(F, M) ]
+type Zqs = '[Zq $(mkTLNatNat 268440577), Zq $(mkTLNatNat 65537), Zq $(mkTLNatNat 1073753089), Zq $(mkTLNatNat 36355)]
+
+squareTwice :: forall c b e expr a . 
+  (a ~ PreMul expr b, b ~ PreMul expr c, Mul expr b, Mul expr c, Lambda expr)
+  => expr e (a -> c)
+squareTwice = lam $ (lam $ v0 *: v0) $: (v0 *: v0)
+
+
+main :: IO ()
+main = evalKeysHints 8.0 $ do
+    f <- argToReader (pt2ct @M'Map @Zqs @TrivGad @Int64) 
+                     (squareTwice @(PNoiseTag ('PN 'Z) (Cyc CT F4 (Zq 7))))
+    f' <- readerToAccumulator . writeErrorRates @Int64 @() $ f
+    arg1 <- getRandom >>= argToReader encrypt
+    liftIO $ mapM_ print $ execWriter $ ((eval f') >>= ($ arg1))


### PR DESCRIPTION
Currently "shared" computations result in duplicate log entries when using ErrorRateWriter. For example:

``` haskell
    squareTwice = lam $ (lam $ v0 *: v0) $: (v0 *: v0)
```
would would have 3 entries indicating multiplication when interpreted with ErrorRateWriter though there are clearly only two multiplications occurring. This is because ERW was functioning as a call-by-name interpreter and so the rightmost `v0 *: v0` was being evaluated twice by the inner function.

This issue is resolved in this PR, principally by altering the Monadify type family. Where the old implementation yielded a very "flat" representation of an object language arrow (e.g. `ERW e ((a -> b) -> c -> d) ~ expr e ((m a -> m b) -> m c -> m d)`) the new version puts everything in the form of a Kleisli arrow (`ERW e ((a -> b) -> c -> d) ~ expr e (m ((a -> m b) -> m (c -> m d)))`). Application is now accomplished by binding object language arguments to object language functions which ensures call-by-value semantics. The new Monadify is injective as well.

**Caveats:**
* `lift` is probably no longer the write semantic for `liftWriteError*` since it no longer behaves analogously to e.g. `liftM`. It should probably be renamed.
* Right now, there is a `liftWriteError' :: String -> Maybe (SK (_)) -> expr e ((a -> ct) -> w (a -> w ct))` helper function that abstracts much of the similarity between `liftWriteError` and `liftWriteError2` (and in fact, `liftWriteError` and `liftWriteError2` are now fairly trivial wrappers around it). The current implementation of these functions feels pretty unclean to me, and I think they can be improved.